### PR TITLE
Prevent duplicate pager IDs

### DIFF
--- a/class.mfcdiscussionpagination.plugin.php
+++ b/class.mfcdiscussionpagination.plugin.php
@@ -38,7 +38,7 @@ class MFCDiscussionPaginationPlugin extends Gdn_Plugin {
       $Sender->Pager->MoreCode = '';
       $Sender->Pager->LessCode = '';
       $Sender->Pager->CssClass = 'MiniPager';
-      $Sender->Pager->ClientID = 'Pager';
+      $Sender->Pager->ClientID = 'Pager'.$Discussion->DiscussionID;
       $Sender->Pager->Wrapper = '<span %1$s>%2$s</span>';
       $Sender->Pager->Configure(
          $Sender->Offset,


### PR DESCRIPTION
Glad, you are maintaining a fork of this plugin 😄 

I was just came across this, tracking down an [old bug](https://open.vanillaforums.com/discussion/comment/242084/#Comment_242084) reported for my infinite scroll plugin. Turns out there are multiple `#PagerAfter` on the document when using this plugin.

Since IDs should be unique anyway, I just added the Discussion ID.